### PR TITLE
 fix: Implement validation for extension_data field in FRProject

### DIFF
--- a/pmp_manip/core/project.py
+++ b/pmp_manip/core/project.py
@@ -144,7 +144,9 @@ class FRProject:
         Returns:
             None
         """
-        # TODO #if self.extension_data != {}: raise MANIP_ThanksError() # also uncomment test
+        if self.extension_data != {}:
+            from pmp_manip.utility import MANIP_ThanksError
+            raise MANIP_ThanksError()
 
     @enforce_argument_types
     def add_all_extensions_to_info_api(self, info_api: OpcodeInfoAPI) -> None:

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -59,12 +59,93 @@ def test_FRProject_from_file():
 
 
 def test_FRProject_post_init():
-    ... # TODO
-    #with raises(MANIP_ThanksError):
-    #    FRProject.from_data(
-    #        data=PROJECT_DATA | {"extensionData": 7}, 
-    #        asset_files=PROJECT_ASSET_FILES,
-    #    )
+    from pytest import raises
+    from pmp_manip.utility import MANIP_ThanksError
+    from pmp_manip.core.meta import FRMeta
+    from pmp_manip.core.target import FRStage, FRSprite
+    
+    # Create a minimal stage and sprite data based on the original PROJECT_DATA structure
+    minimal_stage_data = {
+        "isStage": True,
+        "name": "_stage_",
+        "variables": [],
+        "lists": [],
+        "broadcasts": [],
+        "blocks": {},
+        "comments": {},
+        "currentCostume": 0,
+        "costumes": [{
+            "assetId": "cd21514d0531fdffb22204e0ec5ed84a",
+            "name": "backdrop1",
+            "bitmapResolution": 1,
+            "md5ext": "cd21514d0531fdffb22204e0ec5ed84a.svg",
+            "dataFormat": "svg",
+            "rotationCenterX": 240,
+            "rotationCenterY": 180
+        }],
+        "sounds": [],
+        "volume": 100,
+        "layerOrder": 0,
+        "tempo": 60,
+        "videoTransparency": 50,
+        "videoState": "on",
+        "textToSpeechLanguage": None
+    }
+    
+    minimal_sprite_data = {
+        "isStage": False,
+        "name": "Sprite1",
+        "variables": [],
+        "lists": [],
+        "broadcasts": [],
+        "blocks": {},
+        "comments": {},
+        "currentCostume": 0,
+        "costumes": [{
+            "assetId": "c434b674f2da18ba13cdfe51dbc05ecc",
+            "name": "costume1",
+            "bitmapResolution": 1,
+            "md5ext": "c434b674f2da18ba13cdfe51dbc05ecc.svg",
+            "dataFormat": "svg",
+            "rotationCenterX": 47,
+            "rotationCenterY": 55
+        }],
+        "sounds": [],
+        "volume": 100,
+        "layerOrder": 1,
+        "visible": True,
+        "x": 0,
+        "y": 0,
+        "size": 100,
+        "direction": 90,
+        "draggable": False,
+        "rotationStyle": "normal"
+    }
+    
+    minimal_data = {
+        "targets": [minimal_stage_data, minimal_sprite_data],
+        "monitors": [],
+        "extensionData": 7,  # This should trigger the error
+        "extensions": [],
+        "extensionURLs": {},
+        "meta": {
+            "semver": "3.0.0",
+            "vm": "0.2.0",
+            "agent": "",
+            "platform": {
+                "name": "PenguinMod",
+                "url": "https://penguinmod.com/",
+                "version": "stable",
+            },
+        }
+    }
+    
+    asset_files = {}
+    with raises(MANIP_ThanksError):
+        FRProject.from_data(
+            data=minimal_data, 
+            asset_files=asset_files,
+        )
 
 
 def test_FRProject_add_all_extensions_to_info_api(monkeypatch: MonkeyPatch):


### PR DESCRIPTION
## Summary
    This PR addresses the unimplemented validation for the `extension_data` field in `FRProject`
      class that was previously commented out with a TODO.
    
     ## Changes Made
     1. Implemented the validation in `FRProject.__post_init__()` method that raises `
      MANIP_ThanksError` when `extension_data` is not an empty dictionary `{}`.
     2. Uncommented and updated the corresponding test in `test_FRProject_post_init()` to verify this
      validation works properly.
    
     ## Why this change is needed
     - The validation was previously commented out with a TODO: `# TODO #if self.extension_data !=
      {}: raise MANIP_ThanksError() # also uncomment test`
    - The code comment states: "I could not find out what it would be used for, seems to be always
      {}"
    - This ensures projects maintain the expected format where `extension_data` should always be
      empty
   
    ## Verification
    - Normal project creation with empty extension_data still works
    - Projects with non-empty extension_data now properly raise MANIP_ThanksError
    - Import of modified modules works without syntax errors
    3. Submit the pull request to merge your fix-extension-data-validation branch into the main branch of the
      original repository